### PR TITLE
Add commission config and tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/run.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/config/commission.js
+++ b/backend/src/config/commission.js
@@ -1,0 +1,14 @@
+const defaultRate = parseFloat(process.env.DEFAULT_COMMISSION_RATE || '0.1');
+
+const categoryRates = {
+  homecare: parseFloat(process.env.COMMISSION_HOMECARE || defaultRate),
+  therapy: parseFloat(process.env.COMMISSION_THERAPY || defaultRate),
+};
+
+function getCommissionRate(category) {
+  return categoryRates.hasOwnProperty(category)
+    ? categoryRates[category]
+    : defaultRate;
+}
+
+module.exports = { getCommissionRate };

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -2,6 +2,7 @@ const Payment = require('../models/Payment');
 const Booking = require('../models/Booking');
 const User = require('../models/User');
 const paymentService = require('../services/paymentService');
+const { getCommissionRate } = require('../config/commission');
 
 // Process payment for a booking
 exports.processPayment = async (req, res) => {
@@ -27,8 +28,8 @@ exports.processPayment = async (req, res) => {
       return res.status(400).json({ message: 'This booking has already been paid for' });
     }
     
-    // Calculate commission (for example, 10% of total price)
-    const commissionRate = 0.1; // 10%
+    // Calculate commission based on service category
+    const commissionRate = getCommissionRate(booking.service.category);
     const commissionAmount = booking.totalPrice * commissionRate;
     const providerAmount = booking.totalPrice - commissionAmount;
     

--- a/backend/test/commission.test.js
+++ b/backend/test/commission.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const { getCommissionRate } = require('../src/config/commission');
+
+// default rate
+assert(Math.abs(getCommissionRate('unknown') - 0.1) < 1e-6);
+
+process.env.COMMISSION_HOMECARE = '0.2';
+delete require.cache[require.resolve('../src/config/commission')];
+const { getCommissionRate: fresh } = require('../src/config/commission');
+assert(Math.abs(fresh('homecare') - 0.2) < 1e-6);
+
+console.log('commission tests passed');

--- a/backend/test/run.js
+++ b/backend/test/run.js
@@ -1,0 +1,2 @@
+const tests = [require('./commission.test')];
+console.log(`${tests.length} tests executed`);


### PR DESCRIPTION
## Summary
- enable commission configuration per service category
- test commission configuration with simple node-based tests

## Testing
- `cd backend && npm test --silent`