### PR TITLE
Fix test runner to wait for async tests

### DIFF
--- a/backend/test/payment.test.js
+++ b/backend/test/payment.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const { processPayment } = require('../src/services/paymentService');
 
-(async () => {
+(module.exports = (async () => {
   // card method
   const cardResult = await processPayment({ amount: 50, currency: 'USD', method: 'card', cardInfo: {} });
   assert(cardResult.success);
@@ -15,4 +15,4 @@ const { processPayment } = require('../src/services/paymentService');
   assert(bankResult.success);
 
   console.log('payment tests passed');
-})();
+}))();

--- a/backend/test/run.js
+++ b/backend/test/run.js
@@ -3,4 +3,12 @@ const tests = [
   require('./distance.test'),
   require('./payment.test')
 ];
-console.log(`${tests.length} tests executed`);
+
+(async () => {
+  for (const t of tests) {
+    if (t instanceof Promise) {
+      await t;
+    }
+  }
+  console.log(`${tests.length} tests executed`);
+})();


### PR DESCRIPTION
## Summary
- update payment test to export promise
- modify test runner to await any async tests

## Testing
- `npm test --silent`